### PR TITLE
Optimization/cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.11"
+  - "0.10"

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,23 @@
 'use strict'
 
+var blas1 = require('ndarray-blas-level1')
+
 function dger(alpha, x, y, A) {
   var m = A.shape[0];
   var n = A.shape[1];
-  var temp;
+  var j, yj, Aj;
+  var axpy = blas1.axpy
 
-  for (var j = n - 1; j >= 0; j--) {
-    var y1 = y.get(j);
-    if (y1 != 0) {
-      temp = alpha * y1;
-      for (var i = m - 1; i >= 0; i--) {
-        A.set(i, j, A.get(i, j) + x.get(i) * temp);
-      }
+  Aj = A.pick(null,n-1)
+
+  for( j=n-1; j>=0; j--, Aj.offset-=A.stride[1] ) {
+
+    yj = y.get(j)
+
+    if( yj !== 0 ) {
+      axpy( alpha*yj, x, Aj )
     }
+
   }
 
   return true;

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "ndarray-blas-dger",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "BLAS Level 2 DGER for ndarrays",
   "main": "lib/index.js",
   "author": "Jalmari Raippalinna",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jalava/ndarray-blas-dger.git"
+    "url": "git://github.com/rreusser/ndarray-blas-dger.git"
   },
   "scripts": {
     "test": "mocha",
@@ -16,6 +16,7 @@
   "keywords": [
     "blas",
     "ndarray",
+    "scijs",
     "linearalgebra"
   ],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/rreusser/ndarray-blas-dger.git"
+    "url": "git://github.com/jalava/ndarray-blas-dger.git"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "transform": [
       "cwise"
     ]
+  },
+  "dependencies": {
+    "ndarray-blas-level1": "^1.0.5"
   }
 }


### PR DESCRIPTION
Thanks for the contribution, @jalava! It's appreciated! I made a couple cleanup/optimization changes, specifically:

1. Just tiny boring package.json details.
2. Sorta-vectorized the column multiplications since, in general, it's best to avoid `.get` or `.set` in inner loops. `cwise` isn't perfect either—in particular for small inputs where there's a bit of overhead—but unrolls things into pretty simple loops and so is pretty good for vectorizing operations.
3. based on experimentation, I also just pulled a single slice and modified the offset instead of instantiating a new slice on every loop iteration. It's a little ugly, but based on experimentation elsewhere seemed to bump the performance by 5-15% or something without making it too ugly.

It could almost certainly be optimized a bunch more if we were *really* after performance, but the goal here was to just grab some low-hanging fruit.